### PR TITLE
fix: Bind socket during constructor

### DIFF
--- a/apollo-mockserver/src/concurrentMain/kotlin/com/apollographql/mockserver/TcpServer.concurrent.kt
+++ b/apollo-mockserver/src/concurrentMain/kotlin/com/apollographql/mockserver/TcpServer.concurrent.kt
@@ -49,7 +49,7 @@ class KtorTcpServer(
     require(serverScope.isActive) { "Server is closed and cannot be restarted" }
     require(serverJob == null) { "Server is already started" }
 
-    serverJob = serverScope.launch(start = CoroutineStart.UNDISPATCHED) {
+    serverJob = serverScope.launch {
       while (isActive) {
         if (acceptDelayMillis > 0) {
           delay(acceptDelayMillis.toLong())


### PR DESCRIPTION
# Context

[Discord discussion](https://discord.com/channels/1022972389463687228/1297478313312387092)

After #11, the `serverSocket` was instantiated and bound during the first call of the `listen` method. However, this creates inconsistency due to concurrency in some tests for developers.

The idea is to `bind` the socket during the initialization of the constructor to have the same behavior as before