### PR TITLE
Add support for linuxX64

### DIFF
--- a/.github/workflows/build-pull-request.yaml
+++ b/.github/workflows/build-pull-request.yaml
@@ -11,3 +11,12 @@ jobs:
       - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda #v3.4.2
       - run: |
           ./gradlew build 
+
+  run-linux-tests:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 #v4.1.7
+      - uses: gradle/actions/setup-gradle@dbbdc275be76ac10734476cc723d82dfe7ec6eda #v3.4.2
+      - run: |
+          ./gradlew linuxX64Test 

--- a/apollo-mockserver/api/apollo-mockserver.klib.api
+++ b/apollo-mockserver/api/apollo-mockserver.klib.api
@@ -1,6 +1,6 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
-// Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
+// Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/apollo-mockserver/api/apollo-mockserver.klib.api
+++ b/apollo-mockserver/api/apollo-mockserver.klib.api
@@ -1,6 +1,6 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
-// Alias: apple => [iosArm64, iosSimulatorArm64, iosX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
+// Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true
@@ -17,19 +17,24 @@ abstract interface com.apollographql.mockserver/MockRequestBase { // com.apollog
     abstract val version // com.apollographql.mockserver/MockRequestBase.version|{}version[0]
         abstract fun <get-version>(): kotlin/String // com.apollographql.mockserver/MockRequestBase.version.<get-version>|<get-version>(){}[0]
 }
+
 abstract interface com.apollographql.mockserver/MockServer : okio/Closeable { // com.apollographql.mockserver/MockServer|null[0]
     abstract fun close() // com.apollographql.mockserver/MockServer.close|close(){}[0]
     abstract fun enqueue(com.apollographql.mockserver/MockResponse) // com.apollographql.mockserver/MockServer.enqueue|enqueue(com.apollographql.mockserver.MockResponse){}[0]
     abstract fun takeRequest(): com.apollographql.mockserver/MockRequest // com.apollographql.mockserver/MockServer.takeRequest|takeRequest(){}[0]
+    abstract suspend fun awaitAnyRequest(kotlin.time/Duration = ...): com.apollographql.mockserver/MockRequestBase // com.apollographql.mockserver/MockServer.awaitAnyRequest|awaitAnyRequest(kotlin.time.Duration){}[0]
+    abstract suspend fun port(): kotlin/Int // com.apollographql.mockserver/MockServer.port|port(){}[0]
+    abstract suspend fun url(): kotlin/String // com.apollographql.mockserver/MockServer.url|url(){}[0]
+    open suspend fun stop() // com.apollographql.mockserver/MockServer.stop|stop(){}[0]
+
     abstract interface Listener { // com.apollographql.mockserver/MockServer.Listener|null[0]
         abstract fun onMessage(com.apollographql.mockserver/WebSocketMessage) // com.apollographql.mockserver/MockServer.Listener.onMessage|onMessage(com.apollographql.mockserver.WebSocketMessage){}[0]
         abstract fun onRequest(com.apollographql.mockserver/MockRequestBase) // com.apollographql.mockserver/MockServer.Listener.onRequest|onRequest(com.apollographql.mockserver.MockRequestBase){}[0]
     }
-    abstract suspend fun awaitAnyRequest(kotlin.time/Duration = ...): com.apollographql.mockserver/MockRequestBase // com.apollographql.mockserver/MockServer.awaitAnyRequest|awaitAnyRequest(kotlin.time.Duration){}[0]
-    abstract suspend fun port(): kotlin/Int // com.apollographql.mockserver/MockServer.port|port(){}[0]
-    abstract suspend fun url(): kotlin/String // com.apollographql.mockserver/MockServer.url|url(){}[0]
+
     final class Builder { // com.apollographql.mockserver/MockServer.Builder|null[0]
         constructor <init>() // com.apollographql.mockserver/MockServer.Builder.<init>|<init>(){}[0]
+
         final fun build(): com.apollographql.mockserver/MockServer // com.apollographql.mockserver/MockServer.Builder.build|build(){}[0]
         final fun handlePings(kotlin/Boolean): com.apollographql.mockserver/MockServer.Builder // com.apollographql.mockserver/MockServer.Builder.handlePings|handlePings(kotlin.Boolean){}[0]
         final fun handler(com.apollographql.mockserver/MockServerHandler): com.apollographql.mockserver/MockServer.Builder // com.apollographql.mockserver/MockServer.Builder.handler|handler(com.apollographql.mockserver.MockServerHandler){}[0]
@@ -37,50 +42,64 @@ abstract interface com.apollographql.mockserver/MockServer : okio/Closeable { //
         final fun port(kotlin/Int): com.apollographql.mockserver/MockServer.Builder // com.apollographql.mockserver/MockServer.Builder.port|port(kotlin.Int){}[0]
         final fun tcpServer(com.apollographql.mockserver/TcpServer): com.apollographql.mockserver/MockServer.Builder // com.apollographql.mockserver/MockServer.Builder.tcpServer|tcpServer(com.apollographql.mockserver.TcpServer){}[0]
     }
-    open suspend fun stop() // com.apollographql.mockserver/MockServer.stop|stop(){}[0]
 }
+
 abstract interface com.apollographql.mockserver/MockServerHandler { // com.apollographql.mockserver/MockServerHandler|null[0]
     abstract fun handle(com.apollographql.mockserver/MockRequestBase): com.apollographql.mockserver/MockResponse // com.apollographql.mockserver/MockServerHandler.handle|handle(com.apollographql.mockserver.MockRequestBase){}[0]
 }
+
 abstract interface com.apollographql.mockserver/MultipartBody { // com.apollographql.mockserver/MultipartBody|null[0]
     abstract fun enqueueDelay(kotlin/Long) // com.apollographql.mockserver/MultipartBody.enqueueDelay|enqueueDelay(kotlin.Long){}[0]
     abstract fun enqueuePart(okio/ByteString, kotlin/Boolean) // com.apollographql.mockserver/MultipartBody.enqueuePart|enqueuePart(okio.ByteString;kotlin.Boolean){}[0]
 }
+
 abstract interface com.apollographql.mockserver/TcpServer : okio/Closeable { // com.apollographql.mockserver/TcpServer|null[0]
     abstract fun close() // com.apollographql.mockserver/TcpServer.close|close(){}[0]
     abstract fun listen(kotlin/Function1<com.apollographql.mockserver/TcpSocket, kotlin/Unit>) // com.apollographql.mockserver/TcpServer.listen|listen(kotlin.Function1<com.apollographql.mockserver.TcpSocket,kotlin.Unit>){}[0]
     abstract suspend fun address(): com.apollographql.mockserver/Address // com.apollographql.mockserver/TcpServer.address|address(){}[0]
 }
+
 abstract interface com.apollographql.mockserver/TcpSocket : okio/Closeable { // com.apollographql.mockserver/TcpSocket|null[0]
     abstract fun close() // com.apollographql.mockserver/TcpSocket.close|close(){}[0]
     abstract fun send(kotlin/ByteArray) // com.apollographql.mockserver/TcpSocket.send|send(kotlin.ByteArray){}[0]
     abstract suspend fun receive(): kotlin/ByteArray // com.apollographql.mockserver/TcpSocket.receive|receive(){}[0]
 }
+
 abstract interface com.apollographql.mockserver/WebSocketBody { // com.apollographql.mockserver/WebSocketBody|null[0]
     abstract fun close() // com.apollographql.mockserver/WebSocketBody.close|close(){}[0]
     abstract fun enqueueMessage(com.apollographql.mockserver/WebSocketMessage) // com.apollographql.mockserver/WebSocketBody.enqueueMessage|enqueueMessage(com.apollographql.mockserver.WebSocketMessage){}[0]
 }
+
+sealed interface com.apollographql.mockserver/WebSocketMessage // com.apollographql.mockserver/WebSocketMessage|null[0]
+
 final class com.apollographql.mockserver/Address { // com.apollographql.mockserver/Address|null[0]
     constructor <init>(kotlin/String, kotlin/Int) // com.apollographql.mockserver/Address.<init>|<init>(kotlin.String;kotlin.Int){}[0]
+
     final val hostname // com.apollographql.mockserver/Address.hostname|{}hostname[0]
         final fun <get-hostname>(): kotlin/String // com.apollographql.mockserver/Address.hostname.<get-hostname>|<get-hostname>(){}[0]
     final val port // com.apollographql.mockserver/Address.port|{}port[0]
         final fun <get-port>(): kotlin/Int // com.apollographql.mockserver/Address.port.<get-port>|<get-port>(){}[0]
 }
+
 final class com.apollographql.mockserver/CloseFrame : com.apollographql.mockserver/WebSocketMessage { // com.apollographql.mockserver/CloseFrame|null[0]
     constructor <init>(kotlin/Int?, kotlin/String?) // com.apollographql.mockserver/CloseFrame.<init>|<init>(kotlin.Int?;kotlin.String?){}[0]
+
     final val code // com.apollographql.mockserver/CloseFrame.code|{}code[0]
         final fun <get-code>(): kotlin/Int? // com.apollographql.mockserver/CloseFrame.code.<get-code>|<get-code>(){}[0]
     final val reason // com.apollographql.mockserver/CloseFrame.reason|{}reason[0]
         final fun <get-reason>(): kotlin/String? // com.apollographql.mockserver/CloseFrame.reason.<get-reason>|<get-reason>(){}[0]
 }
+
 final class com.apollographql.mockserver/DataMessage : com.apollographql.mockserver/WebSocketMessage { // com.apollographql.mockserver/DataMessage|null[0]
     constructor <init>(kotlin/ByteArray) // com.apollographql.mockserver/DataMessage.<init>|<init>(kotlin.ByteArray){}[0]
+
     final val data // com.apollographql.mockserver/DataMessage.data|{}data[0]
         final fun <get-data>(): kotlin/ByteArray // com.apollographql.mockserver/DataMessage.data.<get-data>|<get-data>(){}[0]
 }
+
 final class com.apollographql.mockserver/MockRequest : com.apollographql.mockserver/MockRequestBase { // com.apollographql.mockserver/MockRequest|null[0]
     constructor <init>(kotlin/String, kotlin/String, kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/String> = ..., okio/ByteString = ...) // com.apollographql.mockserver/MockRequest.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.String>;okio.ByteString){}[0]
+
     final val body // com.apollographql.mockserver/MockRequest.body|{}body[0]
         final fun <get-body>(): okio/ByteString // com.apollographql.mockserver/MockRequest.body.<get-body>|<get-body>(){}[0]
     final val headers // com.apollographql.mockserver/MockRequest.headers|{}headers[0]
@@ -92,21 +111,10 @@ final class com.apollographql.mockserver/MockRequest : com.apollographql.mockser
     final val version // com.apollographql.mockserver/MockRequest.version|{}version[0]
         final fun <get-version>(): kotlin/String // com.apollographql.mockserver/MockRequest.version.<get-version>|<get-version>(){}[0]
 }
+
 final class com.apollographql.mockserver/MockResponse { // com.apollographql.mockserver/MockResponse|null[0]
     constructor <init>(kotlin/Int = ..., kotlinx.coroutines.flow/Flow<okio/ByteString> = ..., kotlin.collections/Map<kotlin/String, kotlin/String> = ..., kotlin/Long = ...) // com.apollographql.mockserver/MockResponse.<init>|<init>(kotlin.Int;kotlinx.coroutines.flow.Flow<okio.ByteString>;kotlin.collections.Map<kotlin.String,kotlin.String>;kotlin.Long){}[0]
-    final class Builder { // com.apollographql.mockserver/MockResponse.Builder|null[0]
-        constructor <init>() // com.apollographql.mockserver/MockResponse.Builder.<init>|<init>(){}[0]
-        final fun addHeader(kotlin/String, kotlin/String): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.addHeader|addHeader(kotlin.String;kotlin.String){}[0]
-        final fun body(kotlin/String): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.body|body(kotlin.String){}[0]
-        final fun body(kotlinx.coroutines.flow/Flow<okio/ByteString>): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.body|body(kotlinx.coroutines.flow.Flow<okio.ByteString>){}[0]
-        final fun body(okio/ByteString): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.body|body(okio.ByteString){}[0]
-        final fun build(): com.apollographql.mockserver/MockResponse // com.apollographql.mockserver/MockResponse.Builder.build|build(){}[0]
-        final fun delayMillis(kotlin/Long): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.delayMillis|delayMillis(kotlin.Long){}[0]
-        final fun headers(kotlin.collections/Map<kotlin/String, kotlin/String>): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.headers|headers(kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
-        final fun keepAlive(kotlin/Boolean): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.keepAlive|keepAlive(kotlin.Boolean){}[0]
-        final fun statusCode(kotlin/Int): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.statusCode|statusCode(kotlin.Int){}[0]
-    }
-    final fun newBuilder(): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.newBuilder|newBuilder(){}[0]
+
     final val body // com.apollographql.mockserver/MockResponse.body|{}body[0]
         final fun <get-body>(): kotlinx.coroutines.flow/Flow<okio/ByteString> // com.apollographql.mockserver/MockResponse.body.<get-body>|<get-body>(){}[0]
     final val delayMillis // com.apollographql.mockserver/MockResponse.delayMillis|{}delayMillis[0]
@@ -117,17 +125,34 @@ final class com.apollographql.mockserver/MockResponse { // com.apollographql.moc
         final fun <get-keepAlive>(): kotlin/Boolean // com.apollographql.mockserver/MockResponse.keepAlive.<get-keepAlive>|<get-keepAlive>(){}[0]
     final val statusCode // com.apollographql.mockserver/MockResponse.statusCode|{}statusCode[0]
         final fun <get-statusCode>(): kotlin/Int // com.apollographql.mockserver/MockResponse.statusCode.<get-statusCode>|<get-statusCode>(){}[0]
+
+    final fun newBuilder(): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.newBuilder|newBuilder(){}[0]
+
+    final class Builder { // com.apollographql.mockserver/MockResponse.Builder|null[0]
+        constructor <init>() // com.apollographql.mockserver/MockResponse.Builder.<init>|<init>(){}[0]
+
+        final fun addHeader(kotlin/String, kotlin/String): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.addHeader|addHeader(kotlin.String;kotlin.String){}[0]
+        final fun body(kotlin/String): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.body|body(kotlin.String){}[0]
+        final fun body(kotlinx.coroutines.flow/Flow<okio/ByteString>): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.body|body(kotlinx.coroutines.flow.Flow<okio.ByteString>){}[0]
+        final fun body(okio/ByteString): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.body|body(okio.ByteString){}[0]
+        final fun build(): com.apollographql.mockserver/MockResponse // com.apollographql.mockserver/MockResponse.Builder.build|build(){}[0]
+        final fun delayMillis(kotlin/Long): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.delayMillis|delayMillis(kotlin.Long){}[0]
+        final fun headers(kotlin.collections/Map<kotlin/String, kotlin/String>): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.headers|headers(kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
+        final fun keepAlive(kotlin/Boolean): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.keepAlive|keepAlive(kotlin.Boolean){}[0]
+        final fun statusCode(kotlin/Int): com.apollographql.mockserver/MockResponse.Builder // com.apollographql.mockserver/MockResponse.Builder.statusCode|statusCode(kotlin.Int){}[0]
+    }
 }
+
 final class com.apollographql.mockserver/TextMessage : com.apollographql.mockserver/WebSocketMessage { // com.apollographql.mockserver/TextMessage|null[0]
     constructor <init>(kotlin/String) // com.apollographql.mockserver/TextMessage.<init>|<init>(kotlin.String){}[0]
+
     final val text // com.apollographql.mockserver/TextMessage.text|{}text[0]
         final fun <get-text>(): kotlin/String // com.apollographql.mockserver/TextMessage.text.<get-text>|<get-text>(){}[0]
 }
+
 final class com.apollographql.mockserver/WebsocketMockRequest : com.apollographql.mockserver/MockRequestBase { // com.apollographql.mockserver/WebsocketMockRequest|null[0]
     constructor <init>(kotlin/String, kotlin/String, kotlin/String, kotlin.collections/Map<kotlin/String, kotlin/String> = ...) // com.apollographql.mockserver/WebsocketMockRequest.<init>|<init>(kotlin.String;kotlin.String;kotlin.String;kotlin.collections.Map<kotlin.String,kotlin.String>){}[0]
-    final suspend fun awaitClose(kotlin.time/Duration = ...) // com.apollographql.mockserver/WebsocketMockRequest.awaitClose|awaitClose(kotlin.time.Duration){}[0]
-    final suspend fun awaitMessage(kotlin.time/Duration = ...): com.apollographql.mockserver/WebSocketMessage // com.apollographql.mockserver/WebsocketMockRequest.awaitMessage|awaitMessage(kotlin.time.Duration){}[0]
-    final suspend fun awaitMessageOrClose(kotlin.time/Duration = ...): kotlin/Result<com.apollographql.mockserver/WebSocketMessage> // com.apollographql.mockserver/WebsocketMockRequest.awaitMessageOrClose|awaitMessageOrClose(kotlin.time.Duration){}[0]
+
     final val headers // com.apollographql.mockserver/WebsocketMockRequest.headers|{}headers[0]
         final fun <get-headers>(): kotlin.collections/Map<kotlin/String, kotlin/String> // com.apollographql.mockserver/WebsocketMockRequest.headers.<get-headers>|<get-headers>(){}[0]
     final val method // com.apollographql.mockserver/WebsocketMockRequest.method|{}method[0]
@@ -136,9 +161,19 @@ final class com.apollographql.mockserver/WebsocketMockRequest : com.apollographq
         final fun <get-path>(): kotlin/String // com.apollographql.mockserver/WebsocketMockRequest.path.<get-path>|<get-path>(){}[0]
     final val version // com.apollographql.mockserver/WebsocketMockRequest.version|{}version[0]
         final fun <get-version>(): kotlin/String // com.apollographql.mockserver/WebsocketMockRequest.version.<get-version>|<get-version>(){}[0]
+
+    final suspend fun awaitClose(kotlin.time/Duration = ...) // com.apollographql.mockserver/WebsocketMockRequest.awaitClose|awaitClose(kotlin.time.Duration){}[0]
+    final suspend fun awaitMessage(kotlin.time/Duration = ...): com.apollographql.mockserver/WebSocketMessage // com.apollographql.mockserver/WebsocketMockRequest.awaitMessage|awaitMessage(kotlin.time.Duration){}[0]
+    final suspend fun awaitMessageOrClose(kotlin.time/Duration = ...): kotlin/Result<com.apollographql.mockserver/WebSocketMessage> // com.apollographql.mockserver/WebsocketMockRequest.awaitMessageOrClose|awaitMessageOrClose(kotlin.time.Duration){}[0]
 }
+
+final object com.apollographql.mockserver/PingFrame : com.apollographql.mockserver/WebSocketMessage // com.apollographql.mockserver/PingFrame|null[0]
+
+final object com.apollographql.mockserver/PongFrame : com.apollographql.mockserver/WebSocketMessage // com.apollographql.mockserver/PongFrame|null[0]
+
 final const val com.apollographql.mockserver/VERSION // com.apollographql.mockserver/VERSION|{}VERSION[0]
     final fun <get-VERSION>(): kotlin/String // com.apollographql.mockserver/VERSION.<get-VERSION>|<get-VERSION>(){}[0]
+
 final fun (com.apollographql.mockserver/MockServer).com.apollographql.mockserver/assertNoRequest() // com.apollographql.mockserver/assertNoRequest|assertNoRequest@com.apollographql.mockserver.MockServer(){}[0]
 final fun (com.apollographql.mockserver/MockServer).com.apollographql.mockserver/enqueue(kotlin/String = ..., kotlin/Long = ..., kotlin/Int = ...) // com.apollographql.mockserver/enqueue|enqueue@com.apollographql.mockserver.MockServer(kotlin.String;kotlin.Long;kotlin.Int){}[0]
 final fun (com.apollographql.mockserver/MockServer).com.apollographql.mockserver/enqueueError(kotlin/Int) // com.apollographql.mockserver/enqueueError|enqueueError@com.apollographql.mockserver.MockServer(kotlin.Int){}[0]
@@ -152,14 +187,13 @@ final fun (kotlin.collections/Map<kotlin/String, kotlin/String>).com.apollograph
 final fun com.apollographql.mockserver/MockServer(): com.apollographql.mockserver/MockServer // com.apollographql.mockserver/MockServer|MockServer(){}[0]
 final fun com.apollographql.mockserver/MockServer(com.apollographql.mockserver/MockServerHandler): com.apollographql.mockserver/MockServer // com.apollographql.mockserver/MockServer|MockServer(com.apollographql.mockserver.MockServerHandler){}[0]
 final fun com.apollographql.mockserver/TcpServer(kotlin/Int): com.apollographql.mockserver/TcpServer // com.apollographql.mockserver/TcpServer|TcpServer(kotlin.Int){}[0]
-final object com.apollographql.mockserver/PingFrame : com.apollographql.mockserver/WebSocketMessage // com.apollographql.mockserver/PingFrame|null[0]
-final object com.apollographql.mockserver/PongFrame : com.apollographql.mockserver/WebSocketMessage // com.apollographql.mockserver/PongFrame|null[0]
 final suspend fun (com.apollographql.mockserver/MockServer).com.apollographql.mockserver/awaitRequest(kotlin.time/Duration = ...): com.apollographql.mockserver/MockRequest // com.apollographql.mockserver/awaitRequest|awaitRequest@com.apollographql.mockserver.MockServer(kotlin.time.Duration){}[0]
 final suspend fun (com.apollographql.mockserver/MockServer).com.apollographql.mockserver/awaitWebSocketRequest(kotlin.time/Duration = ...): com.apollographql.mockserver/WebsocketMockRequest // com.apollographql.mockserver/awaitWebSocketRequest|awaitWebSocketRequest@com.apollographql.mockserver.MockServer(kotlin.time.Duration){}[0]
-sealed interface com.apollographql.mockserver/WebSocketMessage // com.apollographql.mockserver/WebSocketMessage|null[0]
-// Targets: [apple]
+
+// Targets: [native]
 final class com.apollographql.mockserver/KtorTcpServer : com.apollographql.mockserver/TcpServer { // com.apollographql.mockserver/KtorTcpServer|null[0]
     constructor <init>(kotlin/Int = ..., kotlin/Int = ..., kotlinx.coroutines/CoroutineDispatcher = ...) // com.apollographql.mockserver/KtorTcpServer.<init>|<init>(kotlin.Int;kotlin.Int;kotlinx.coroutines.CoroutineDispatcher){}[0]
+
     final fun close() // com.apollographql.mockserver/KtorTcpServer.close|close(){}[0]
     final fun listen(kotlin/Function1<com.apollographql.mockserver/TcpSocket, kotlin/Unit>) // com.apollographql.mockserver/KtorTcpServer.listen|listen(kotlin.Function1<com.apollographql.mockserver.TcpSocket,kotlin.Unit>){}[0]
     final suspend fun address(): com.apollographql.mockserver/Address // com.apollographql.mockserver/KtorTcpServer.address|address(){}[0]

--- a/apollo-mockserver/build.gradle.kts
+++ b/apollo-mockserver/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
   tvosArm64()
   tvosX64()
   tvosSimulatorArm64()
+  linuxX64()
   js(IR) {
     nodejs()
   }
@@ -35,8 +36,10 @@ kotlin {
         group("concurrent") {
           group("apple")
           withJvm()
+          withLinuxX64()
         }
         withJvm()
+        withLinuxX64()
       }
     }
   }

--- a/apollo-mockserver/build.gradle.kts
+++ b/apollo-mockserver/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
   tvosArm64()
   tvosX64()
   tvosSimulatorArm64()
+  linuxArm64()
   linuxX64()
   js(IR) {
     nodejs()
@@ -36,9 +37,11 @@ kotlin {
         group("concurrent") {
           group("apple")
           withJvm()
+          withLinuxArm64()
           withLinuxX64()
         }
         withJvm()
+        withLinuxArm64()
         withLinuxX64()
       }
     }


### PR DESCRIPTION
Adding support for Linux X86 as part of attempting to add support  in `apollo-kotlin`.

To locally run `check` without error I also needed to run `apiDump` though I was unsure if I should be committing those changes directly. I can revert the api changes if that was a mistake.

Ref: https://github.com/apollographql/apollo-kotlin/issues/3483