### PR TITLE
Add watchosDeviceArm64 target

### DIFF
--- a/apollo-mockserver/api/apollo-mockserver.klib.api
+++ b/apollo-mockserver/api/apollo-mockserver.klib.api
@@ -1,6 +1,6 @@
 // Klib ABI Dump
-// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosSimulatorArm64]
-// Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosSimulatorArm64]
+// Targets: [iosArm64, iosSimulatorArm64, iosX64, js, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, wasmJs, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
+// Alias: native => [iosArm64, iosSimulatorArm64, iosX64, linuxArm64, linuxX64, macosArm64, macosX64, tvosArm64, tvosSimulatorArm64, tvosX64, watchosArm32, watchosArm64, watchosDeviceArm64, watchosSimulatorArm64]
 // Rendering settings:
 // - Signature version: 2
 // - Show manifest properties: true

--- a/apollo-mockserver/build.gradle.kts
+++ b/apollo-mockserver/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
   iosSimulatorArm64()
   watchosArm32()
   watchosArm64()
+  watchosDeviceArm64()
   watchosSimulatorArm64()
   tvosArm64()
   tvosX64()


### PR DESCRIPTION
In April 2026 WatchOS will require Arm64 as an architecture.

Whilst `watchosArm64()` is already listed, I believe it only adds support for Arm64_32.

I believe `watchosDeviceArm64()` will be required for Arm64

I'm not sure if there are other changes required for this PR!

#### Related: 
- https://github.com/apollographql/apollo-kotlin-mockserver/pull/39
- https://github.com/apollographql/apollo-kotlin/pull/6791
- https://github.com/apollographql/apollo-kotlin-adapters/pull/41
- https://github.com/apollographql/apollo-kotlin-normalized-cache/pull/262
- https://github.com/apollographql/apollo-kotlin-ktor-support/pull/27